### PR TITLE
Add support for per-request prefix generation

### DIFF
--- a/lib/uppy/s3_multipart/app.rb
+++ b/lib/uppy/s3_multipart/app.rb
@@ -11,7 +11,7 @@ module Uppy
       def initialize(bucket:, prefix: nil, public: nil, options: {})
         @router = Class.new(Router)
         @router.opts[:client]  = Client.new(bucket: bucket)
-        @router.opts[:prefix]  = prefix
+        @router.opts[:prefix]  = options[:dynamic_prefix] || prefix
         @router.opts[:public]  = public
         @router.opts[:options] = options
       end
@@ -38,7 +38,10 @@ module Uppy
 
             extension = File.extname(filename.to_s)
             key       = SecureRandom.hex + extension
-            key       = "#{opts[:prefix]}/#{key}" if opts[:prefix]
+            if prefix = opts[:prefix]
+              prefix = prefix.call(env) if prefix.respond_to?(:call)
+              key = "#{prefix}/#{key}" 
+            end
 
             content_disposition = ContentDisposition.inline(filename) if filename
 


### PR DESCRIPTION
This allows Shrine users to specify a lambda to dynamically determine the bucket's prefix on a per-request basis.

*Motivation*: I'm setting up a multi-tenant app where each tenant's users should be able to upload files directly to S3.  Our S3 architecture separates tenant files by prefix. Before this PR I couldn't figure out any other way of setting a non-static prefix, but now I'm able to do the following:
```ruby
Shrine.plugin :uppy_s3_multipart, options: {
  dynamic_prefix: -> (env) {
    raise "Unauthorized upload attempt" unless current_user = env['warden'].user
    # ... determine appropriate prefix for this user's org
  }
}

```

