### PR TITLE
Return 204 for /s3/multipart/:upload_id/:part_no

### DIFF
--- a/lib/uppy/s3_multipart/app.rb
+++ b/lib/uppy/s3_multipart/app.rb
@@ -59,6 +59,11 @@ module Uppy
             r.halt 204
           end
 
+          # OPTIONS /s3/multipart/:uploadId/:partNumber
+          r.options String, String do |upload_id, part_number|
+            r.halt 204
+          end
+
           # GET /s3/multipart/:uploadId
           r.get String do |upload_id|
             key = param!("key")

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -110,6 +110,16 @@ describe Uppy::S3Multipart::App do
     end
   end
 
+  describe "OPTIONS /s3/multipart/:uploadId/:partNumber" do
+    it "returns an empty response" do
+      response = app.options "/s3/multipart/foo/1"
+
+      assert_equal 204,      response.status
+      assert_equal Hash.new, response.headers
+      assert_equal "",       response.body_binary
+    end
+  end
+
   describe "OPTIONS /s3/multipart" do
     it "returns an empty response" do
       response = app.options "/s3/multipart"


### PR DESCRIPTION
https://github.com/janko/uppy-s3_multipart/issues/19

The Uppy JS calls

OPTIONS /s3/multipart/:upload_id/:part_no

this PR adds that route to return 204