### PR TITLE
Handle Aws::S3::Errors::NoSuchUpload error better

### DIFF
--- a/lib/uppy/s3_multipart/app.rb
+++ b/lib/uppy/s3_multipart/app.rb
@@ -103,7 +103,14 @@ module Uppy
           r.delete String do |upload_id|
             key = param!("key")
 
-            client_call(:abort_multipart_upload, upload_id: upload_id, key: key)
+            begin
+              client_call(:abort_multipart_upload, upload_id: upload_id, key: key)
+            rescue Aws::S3::Errors::NoSuchUpload
+              error!(
+                "Upload doesn't exist for \"key\" parameter",
+                status: 404
+              )
+            end
 
             {}
           end
@@ -128,8 +135,8 @@ module Uppy
           value
         end
 
-        def error!(message)
-          request.halt 400, { error: message }
+        def error!(message, status: 400)
+          request.halt status, { error: message }
         end
       end
     end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -358,6 +358,17 @@ describe Uppy::S3Multipart::App do
       assert_equal "Missing \"key\" parameter", response.body_json["error"]
     end
 
+    it "returns error response when 'key' parameter is for an upload that doesn't exist" do
+      @s3.stub_responses(:abort_multipart_upload, 'NoSuchUpload')
+
+      response = app.delete "/s3/multipart/null", query: { key: "null" }
+
+      assert_equal 404, response.status
+      assert_equal "application/json", response.headers["Content-Type"]
+
+      assert_equal "Upload doesn't exist for \"key\" parameter", response.body_json["error"]
+    end
+
     it "handles :options as a hash" do
       @endpoint = Uppy::S3Multipart::App.new(bucket: @bucket, options: {
         abort_multipart_upload: { request_payer: "bob" }


### PR DESCRIPTION
Instead of raising an Aws::S3::Errors::NoSuchUpload error, we return a 404. I think I've got this done correctly but honestly not 100%. Let me know your thoughts. This is to address #18.